### PR TITLE
Update README instructions to use a "dot directory" for the venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This repository is a fork of [daplink-validation](https://os.mbed.com/users/c1728p9/code/daplink-validation).
 
 ```
-$ virtualenv venv
-$ source venv/bin/activate
+$ virtualenv .venv
+$ source .venv/bin/activate
 $ pip install mbed-cli
 $ mbed config root .
 $ mbed toolchain GCC_ARM


### PR DESCRIPTION
Not sure why but when using the `venv` as a directory name the build scripts tried to link .o files from the venv folder:

```
$ /Users/microbit-carlos/workspace/microbit-foundation/daplink-validation/venv/bin/python3.6 -u /Users/microbit-carlos/workspace/microbit-foundation/daplink-validation/mbed-os/tools/make.py -t GCC_ARM -m K22F --profile release --source . --build ./BUILD/K22F/GCC_ARM-RELEASE --verbose
[Warning] @,: Compiler version mismatch: Have 10.2.1; expected version >= 9.0.0 and < 10.0.0
Building project daplink-validation (K22F, GCC_ARM)
Scan: daplink-validation
Macros: -DTARGET_FRDM -DDEVICE_SERIAL=1 -DTARGET_M4 -DDEVICE_ANALOGOUT=1 -DTARGET_RTOS_M4_M7 -DDEVICE_TRNG=1 -DTOOLCHAIN_GCC_ARM -D__CMSIS_RTOS -DDEVICE_I2C=1 -D__FPU_PRESENT=1 -DTARGET_KSDK2_MCUS -DCPU_MK22FN512VLH12 -DTOOLCHAIN_GCC -DMBED_BUILD_TIMESTAMP=1639133635.727605 -DDEVICE_LPTICKER=1 -DDEVICE_PORTINOUT=1 -DDEVICE_USBDEVICE=1 -DTARGET_Freescale -DTARGET_FF_ARDUINO -DTARGET_MCU_K22F512 -DDEVICE_PWMOUT=1 -DFSL_RTOS_MBED -DDEVICE_SLEEP=1 -DDEVICE_INTERRUPTIN=1 -DTARGET_CORTEX -DCOMPONENT_PSA_SRV_IMPL=1 -DTARGET_NAME=K22F -D__MBED__=1 -DDEVICE_RTC=1 -DDEVICE_PORTIN=1 -DDEVICE_I2CSLAVE=1 -DDEVICE_FLASH=1 -DDEVICE_PORTOUT=1 -DTARGET_RELEASE -DTARGET_KPSDK_MCUS -DDEVICE_SPISLAVE=1 -DDEVICE_SPI=1 -D__CORTEX_M4 -DTARGET_MCUXpresso_MCUS -DDEVICE_ANALOGIN=1 -DCOMPONENT_FLASHIAP=1 -D__MBED_CMSIS_RTOS_CM -DTARGET_CORTEX_M -DTARGET_K22F -DTARGET_KPSDK_CODE -DCOMPONENT_NSPE=1 -DTARGET_LIKE_CORTEX_M4 -DMBED_TICKLESS -DCOMPONENT_PSA_SRV_EMUL=1 -DDEVICE_USTICKER=1 -DDEVICE_STDIO_MESSAGES=1 -DTARGET_LIKE_MBED -DTARGET_MCU_K22F -DARM_MATH_CM4
Link: daplink-validation
Preproc: arm-none-eabi-cpp -E -P ./mbed-os/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/device/TOOLCHAIN_GCC_ARM/MK22FN512xxx12.ld -Wl,--gc-sections -Wl,--wrap,main -Wl,--wrap,_malloc_r -Wl,--wrap,_free_r -Wl,--wrap,_realloc_r -Wl,--wrap,_memalign_r -Wl,--wrap,_calloc_r -Wl,--wrap,exit -Wl,--wrap,atexit -Wl,-n -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -DMBED_BOOT_STACK_SIZE=4096 -DXIP_ENABLE=0 -o ./BUILD/K22F/GCC_ARM-RELEASE/.link_script.ld -DTARGET_FRDM -DDEVICE_SERIAL=1 -DTARGET_M4 -DDEVICE_ANALOGOUT=1 -DTARGET_RTOS_M4_M7 -DDEVICE_TRNG=1 -DTOOLCHAIN_GCC_ARM -D__CMSIS_RTOS -DDEVICE_I2C=1 -D__FPU_PRESENT=1 -DTARGET_KSDK2_MCUS -DCPU_MK22FN512VLH12 -DTOOLCHAIN_GCC -DMBED_BUILD_TIMESTAMP=1639133635.727605 -DDEVICE_LPTICKER=1 -DDEVICE_PORTINOUT=1 -DDEVICE_USBDEVICE=1 -DTARGET_Freescale -DTARGET_FF_ARDUINO -DTARGET_MCU_K22F512 -DDEVICE_PWMOUT=1 -DFSL_RTOS_MBED -DDEVICE_SLEEP=1 -DDEVICE_INTERRUPTIN=1 -DTARGET_CORTEX -DCOMPONENT_PSA_SRV_IMPL=1 -DTARGET_NAME=K22F -D__MBED__=1 -DDEVICE_RTC=1 -DDEVICE_PORTIN=1 -DDEVICE_I2CSLAVE=1 -DDEVICE_FLASH=1 -DDEVICE_PORTOUT=1 -DTARGET_RELEASE -DTARGET_KPSDK_MCUS -DDEVICE_SPISLAVE=1 -DDEVICE_SPI=1 -D__CORTEX_M4 -DTARGET_MCUXpresso_MCUS -DDEVICE_ANALOGIN=1 -DCOMPONENT_FLASHIAP=1 -D__MBED_CMSIS_RTOS_CM -DTARGET_CORTEX_M -DTARGET_K22F -DTARGET_KPSDK_CODE -DCOMPONENT_NSPE=1 -DTARGET_LIKE_CORTEX_M4 -DMBED_TICKLESS -DCOMPONENT_PSA_SRV_EMUL=1 -DDEVICE_USTICKER=1 -DDEVICE_STDIO_MESSAGES=1 -DTARGET_LIKE_MBED -DTARGET_MCU_K22F -DARM_MATH_CM4 @./BUILD/K22F/GCC_ARM-RELEASE/.includes_d41d8cd98f00b204e9800998ecf8427e.txt -include ./BUILD/K22F/GCC_ARM-RELEASE/mbed_config.h
[DEBUG] Return: 0
Link: arm-none-eabi-gcc @./BUILD/K22F/GCC_ARM-RELEASE/.link_options.txt
[DEBUG] Return: 1
[DEBUG] Errors: ./venv/lib/python3.6/config-3.6m-darwin/python.o: file not recognized: file format not recognized
[DEBUG] Errors: collect2: error: ld returned 1 exit status
Traceback (most recent call last):
  File "/Users/microbit-carlos/workspace/microbit-foundation/daplink-validation/mbed-os/tools/make.py", line 78, in wrapped_build_project
    *args, **kwargs
  File "/Users/microbit-carlos/workspace/microbit-foundation/daplink-validation/mbed-os/tools/build_api.py", line 598, in build_project
    res = toolchain.link_program(resources, build_path, name)
  File "/Users/microbit-carlos/workspace/microbit-foundation/daplink-validation/mbed-os/tools/toolchains/mbed_toolchain.py", line 773, in link_program
    self.link(elf, objects, libraries, lib_dirs, linker_script)
  File "/Users/microbit-carlos/workspace/microbit-foundation/daplink-validation/mbed-os/tools/toolchains/gcc.py", line 283, in link
    self.default_cmd(cmd)
  File "/Users/microbit-carlos/workspace/microbit-foundation/daplink-validation/mbed-os/tools/toolchains/mbed_toolchain.py", line 825, in default_cmd
    raise ToolException(stderr)
tools.utils.ToolException: ./venv/lib/python3.6/config-3.6m-darwin/python.o: file not recognized: file format not recognized
collect2: error: ld returned 1 exit status
```

The link file generated does have this `./venv/lib/python3.6/config-3.6m-darwin/python.o` as the first .o entry:

```
-Wl,--gc-sections -Wl,--wrap,main -Wl,--wrap,_malloc_r -Wl,--wrap,_free_r -Wl,--wrap,_realloc_r -Wl,--wrap,_memalign_r -Wl,--wrap,_calloc_r -Wl,--wrap,exit -Wl,--wrap,atexit -Wl,-n -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -DMBED_BOOT_STACK_SIZE=4096 -DXIP_ENABLE=0 -o ./BUILD/K22F/GCC_ARM-RELEASE/daplink-validation.elf -Wl,-Map=./BUILD/K22F/GCC_ARM-RELEASE/daplink-validation.map ./venv/lib/python3.6/config-3.6m-darwin/python.o BUILD/K22F/GCC_ARM-RELEASE/mbed-os/cmsis/TARGET_CORTEX_M/mbed_tz_context.o 
```

Using conventional `.venv` directory name does resolve this.